### PR TITLE
Ignoring line-height for superscripts

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -190,6 +190,10 @@ kbd {
     vertical-align: middle;
 }
 
+sup {
+    line-height: 0;
+}
+
 :not(.footnote-definition) + .footnote-definition,
 .footnote-definition + :not(.footnote-definition) {
     margin-block-start: 2em;
@@ -200,10 +204,6 @@ kbd {
 }
 .footnote-definition p {
     display: inline;
-}
-
-.footnote-reference{
-    line-height: 0;
 }
 
 .tooltiptext {


### PR DESCRIPTION
Changed line-height being ignored for all superscripts instead of just footnote-references.